### PR TITLE
Release GIL on C++ wrapped code

### DIFF
--- a/cpp/setup.py
+++ b/cpp/setup.py
@@ -21,7 +21,7 @@ if platform == "linux" or platform == "linux2":
                                                         ],
 							extra_compile_args=['-std=c++11'],
 							libraries=['bluetooth'],
-                                                        swig_opts=['-c++','-py3'],
+                                                        swig_opts=['-c++','-py3','-threads'],
 							)
 elif platform == "win32":
 	attyscomm_module = Extension('_pyattyscomm',
@@ -29,7 +29,7 @@ elif platform == "win32":
 							extra_compile_args=['/DWIN32_LEAN_AND_MEAN'],
                                                         libraries=['ws2_32'],
 							extra_link_args=['Release\\attyscomm_static.lib'],
-                                                        swig_opts=['-c++','-py3'],
+                                                        swig_opts=['-c++','-py3','-threads'],
 							)
 
 						   


### PR DESCRIPTION
This allows users to run Attys code in multiple Python threads without having the thread running Attys code block everything up. Due to CPython's nasty [Global Interpreter Lock](https://wiki.python.org/moin/GlobalInterpreterLock), most Pythons can't truly run two threads at once.

However, once wrapped C++ code is reached, it's generally thought of as "safe" to release the GIL, allowing Python to run the C++ truly concurrently.  
To be entirely honest, I don't know all the specifics - I just know that OpenCV and NumPy both release the GIL at wrapped C++ code.

This patch releases the GIL with Swig's [`-threads` option.](http://www.swig.org/Doc4.0/Python.html#Python_multithreaded) It's not very well tuned or tested, but it does release the GIL when running C++ code.